### PR TITLE
Add svelte to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Gorgeous flag components for your Svelte project.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "svelte": "src/Flag.svelte",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w"


### PR DESCRIPTION
# Add Svelte to Package

Add the `svelte` key to package to json that refers to `src/Flag.svelte`. This gives the package the ability to use the svelte code when the project is made with svelte. 